### PR TITLE
Update cache_control.js

### DIFF
--- a/tasks/cache_control.js
+++ b/tasks/cache_control.js
@@ -214,6 +214,9 @@ module.exports = function(grunt) {
         grunt.fatal("Unable to write file. Destination needs to be provided via outputDest in options or replace set to true.");
       }
     }
+    
+    // tell grunt this task is done
+    done();
 
     // Iterate over all specified file groups.
 //    this.files.forEach(function(f) {


### PR DESCRIPTION
Call done() when task is complete.  

I was trying to use your cache_control task but grunt would stop processing when the cache_control task completed.   I'm pretty new to grunt so this might be design but it appears that calling done() allows cache_control to be used in conjunction with other tasks.

For example:

```
grunt.registerTask('dojo-build-patch', 'Building using dojo\'s build system. The release name can be specified on command line ( --releaseName=viewer ).  The default name is \'viewer\'.', ['clean:dojo','bump:patch','cache_control:dojo', 'htmlmin:dojo','cssmin:dojo','imagemin:dojo','copy:dojo','dojo:prod', 'compress:dojo']);
```

Before adding the proposed changes the task would stop before the htmlmin:dojo task.

Thanks!
